### PR TITLE
使い勝手向上

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -1,6 +1,6 @@
 class ChannelsController < ApplicationController
   def index
-    @channels = Channel.all
+    @channels = Channel.order(created_at: :asc)
     render json: @channels
   end
 

--- a/app/javascript/packs/components/main.jsx
+++ b/app/javascript/packs/components/main.jsx
@@ -138,7 +138,7 @@ class Main extends React.Component {
           const targetChannel = this.state.channels[targetChannelIndex];
           const targetTalkIndex = targetChannel.talks.findIndex(function(o) { return o.id === talk.id }.bind(this));
           var channel;
-          if (targetTalkIndex > 0) {
+          if (targetTalkIndex > -1) {
             var targetTalks = targetChannel.talks
             targetTalks.splice(targetTalkIndex, 1, talk)
             channel = {id: targetChannel.id, name: targetChannel.name, talks: targetTalks};
@@ -184,7 +184,7 @@ class Main extends React.Component {
         } else {
           const targetChannelIndex = this.state.channels.findIndex(function(o) { return o.id === channel.id }.bind(this));
           const targetChannel = this.state.channels[targetChannelIndex];
-          if (targetChannelIndex > 0) {
+          if (targetChannelIndex > -1) {
             const targetTalks = targetChannel.talks
             const newChannel = {id: channel.id, name: channel.name, talks: targetTalks};
             var _channels = this.state.channels.slice();


### PR DESCRIPTION
* [x] 先頭のメッセージを編集したときにメッセージが重複して表示される現象の解消
* [x] チャンネルの並びが固定でなく、チャンネル名編集後に並びが変わる状態になっていたので並びを固定した